### PR TITLE
Transform newlines to paragraphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ dist
 node_modules
 npm-debug.log
 bower_components
-.DS_Store
+.*
+!.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ dist
 node_modules
 npm-debug.log
 bower_components
-.*
-!.gitignore
+.DS_Store
+.test.js

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ function encodeAttr(str) {
 // Moved links to global scope
 // This allows all block parsers to handle reference urls
 //
-// Again, I'm not sure that this is a good solution, maybe urls should
+// I'm not sure that this is a good solution, maybe urls should
 // be passed as second parameter to parse fn for nested parses?
 //
 // function parse(md, links) {
@@ -52,7 +52,7 @@ export default function parse(md) {
 	//    one targets usual case, start of string or lots of newlines folowed by text,
 	//    followed by 2+ newlines - ((?:^|\n+)(?:[\s\S]+?)(?=\n{2,}))
 	//
-	//    second targets specifically last paragraph in group (\n{2,}[\s\S]+)
+	//    second targets specifically last paragraph in group (\n+[\s\S]+)
 
 	// 4. changed end of both regexps for headings
 	//    from (?:\n+|$)
@@ -60,7 +60,13 @@ export default function parse(md) {
 	//
 	//    (it leaves newlines for paragraphs untouched)
 
-	let tokenizer = /((?:^|\n+)(?:\n---+|\* \*(?: \*)+)\n)|(?:(?:^|\n+)```(\w*)\n([\s\S]*?)\n```$)|((?:(?:^|\n+)(?:\t|  {2,}).+)+\n*)|((?:(?:^|\n)([>*+-]|\d+\.)\s+.*)+)|(?:\!\[([^\]]*?)\]\(([^\)]+?)\))|(\[)|(\](?:\(([^\)]+?)\))?)|(?:(?:^|\n+)([^\s].*)\n(\-{3,}|={3,})(?=\n+|$))|(?:(?:^|\n+)(#{1,3})\s*(.+)(?=\n+|$))|(?:`([^`].*?)`)|(  \n\n*|__|\*\*|[_*])|((?:^|\n+)(?:[\s\S]+?)(?=\n{2,}))|(\n{2,}[\s\S]+)/gm,
+	// 5. changed end of <hr /> regexp
+	//    from \n
+	//    to   (?=\n)
+	//
+	//    (again, it leaves newlines untouched for paragraphs)
+
+	let tokenizer = /((?:^|\n+)(?:\n---+|\* \*(?: \*)+)(?=\n))|(?:(?:^|\n+)```(\w*)\n([\s\S]*?)\n```$)|((?:(?:^|\n+)(?:\t|  {2,}).+)+\n*)|((?:(?:^|\n)([>*+-]|\d+\.)\s+.*)+)|(?:\!\[([^\]]*?)\]\(([^\)]+?)\))|(\[)|(\](?:\(([^\)]+?)\))?)|(?:(?:^|\n+)([^\s].*)\n(\-{3,}|={3,})(?=\n+|$))|(?:(?:^|\n+)(#{1,3})\s*(.+)(?=\n+|$))|(?:`([^`].*?)`)|(  \n\n*|__|\*\*|[_*])|((?:^|\n+)(?:[\s\S]+?)(?=\n{2,}))|(\n+[\s\S]+)/gm,
 		context = [],
 		out = '',
 		last = 0,

--- a/src/index.js
+++ b/src/index.js
@@ -22,12 +22,37 @@ function encodeAttr(str) {
 
 /** Parse Markdown into an HTML String. */
 export default function parse(md) {
-	let tokenizer = /((?:^|\n+)(?:\n---+|\* \*(?: \*)+)\n)|(?:^```(\w*)\n([\s\S]*?)\n```$)|((?:(?:^|\n+)(?:\t|  {2,}).+)+\n*)|((?:(?:^|\n)([>*+-]|\d+\.)\s+.*)+)|(?:\!\[([^\]]*?)\]\(([^\)]+?)\))|(\[)|(\](?:\(([^\)]+?)\))?)|(?:(?:^|\n+)([^\s].*)\n(\-{3,}|={3,})(?:\n+|$))|(?:(?:^|\n+)(#{1,3})\s*(.+)(?:\n+|$))|(?:`([^`].*?)`)|(  \n\n*|\n{2,}|__|\*\*|[_*])/gm,
+	// let tokenizer = /((?:^|\n+)(?:\n---+|\* \*(?: \*)+)\n)|(?:^```(\w*)\n([\s\S]*?)\n```$)|((?:(?:^|\n+)(?:\t|  {2,}).+)+\n*)|((?:(?:^|\n)([>*+-]|\d+\.)\s+.*)+)|(?:\!\[([^\]]*?)\]\(([^\)]+?)\))|(\[)|(\](?:\(([^\)]+?)\))?)|(?:(?:^|\n+)([^\s].*)\n(\-{3,}|={3,})(?:\n+|$))|(?:(?:^|\n+)(#{1,3})\s*(.+)(?:\n+|$))|(?:`([^`].*?)`)|(  \n\n*|\n{2,}|__|\*\*|[_*])/gm,
+
+	// 1. changed code regexp
+	//    from (?:^```(\w*)\n([\s\S]*?)\n```$)
+	//    to   (?:(?:^|\n+)```(\w*)\n([\s\S]*?)\n```$)
+
+	// 2. changed inline regexp
+	//    from (  \n\n*|\n{2,}|__|\*\*|[_*])
+	//    to   (  \n\n*|__|\*\*|[_*])
+	//
+	//    (not shure what '  \n\n*' does)
+
+	// 3. added two paragraph regexes
+	//
+	//    one targets usual case, start of string or lots of newlines folowed by text,
+	//    followed by 2+ newlines - ((?:^|\n+)(?:[\s\S]+?)(?=\n{2,}))
+	//
+	//    second targets specifically last paragraph in group (\n{2,}[\s\S]+)
+
+	// 4. changed end of both regexps for headings
+	//    from (?:\n+|$)
+	//    to   (?=\n+|$)
+	//
+	//    (it leaves newlines for paragraphs untouched)
+
+	let tokenizer = /((?:^|\n+)(?:\n---+|\* \*(?: \*)+)\n)|(?:(?:^|\n+)```(\w*)\n([\s\S]*?)\n```$)|((?:(?:^|\n+)(?:\t|  {2,}).+)+\n*)|((?:(?:^|\n)([>*+-]|\d+\.)\s+.*)+)|(?:\!\[([^\]]*?)\]\(([^\)]+?)\))|(\[)|(\](?:\(([^\)]+?)\))?)|(?:(?:^|\n+)([^\s].*)\n(\-{3,}|={3,})(?=\n+|$))|(?:(?:^|\n+)(#{1,3})\s*(.+)(?=\n+|$))|(?:`([^`].*?)`)|(  \n\n*|__|\*\*|[_*])|((?:^|\n+)(?:[\s\S]+?)(?=\n{2,}))|(\n{2,}[\s\S]+)/gm,
 		context = [],
 		out = '',
 		last = 0,
 		links = {},
-		chunk, prev, token, inner, t;
+		chunk, prev, token, inner, t, p;
 
 	function tag(token) {
 		var desc = TAGS[token.replace(/\*/g,'_')[1] || ''],
@@ -44,10 +69,12 @@ export default function parse(md) {
 		return str;
 	}
 
-	md = md.replace(/^\n+|\n+$/g, '').replace(/^\[(.+?)\]:\s*(.+)$/gm, (s, name, url) => {
+	// Moved 'trim' to the end of chain because reference links
+	// could leave trailing newlines
+	md = md.replace(/^\[(.+?)\]:\s*(.+)$/gm, (s, name, url) => {
 		links[name.toLowerCase()] = url;
 		return '';
-	});
+	}).replace(/^\n+|\n+$/g, '');
 
 	while ( (token=tokenizer.exec(md)) ) {
 		prev = md.substring(last, token.index);
@@ -99,6 +126,19 @@ export default function parse(md) {
 		else if (token[17] || token[1]) {
 			chunk = tag(token[17] || '--');
 		}
+		// Paragraphs
+		else if (token[18] || token[19]) {
+			p = (token[18] || token[19]).trim()
+			// Right now there is a problem with p regexp,
+			// lists are included in it too, this checks for list once again.
+			// I don't like this solution, but can't come up with other one for
+			// this moment
+			if (/([>*+-]|\d+\.)\s+.*/.test(p)) chunk = parse(p);
+			else {
+				chunk = '<p>' + parse(p) + '</p>';
+			}
+		}
+
 		out += prev;
 		out += chunk;
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,7 @@ export default function parse(md) {
 			// lists are included in it too, this checks for list once again.
 			// I don't like this solution, but can't come up with other one for
 			// this moment
-			if (/([>*+-]|\d+\.)\s+.*/.test(p)) chunk = parse(p);
+			if (/(?:^|\n)([>*+-]|\d+\.)\s+.*/.test(p)) chunk = parse(p);
 			else {
 				chunk = '<p>' + parse(p) + '</p>';
 			}

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,19 @@ function encodeAttr(str) {
 	return (str+'').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
+// Moved links to global scope
+// This allows all block parsers to handle reference urls
+//
+// Again, I'm not sure that this is a good solution, maybe urls should
+// be passed as second parameter to parse fn for nested parses?
+//
+// function parse(md, links) {
+// ...
+//     let links = links || {};
+// ...
+// }
+let links = {};
+
 /** Parse Markdown into an HTML String. */
 export default function parse(md) {
 	// let tokenizer = /((?:^|\n+)(?:\n---+|\* \*(?: \*)+)\n)|(?:^```(\w*)\n([\s\S]*?)\n```$)|((?:(?:^|\n+)(?:\t|  {2,}).+)+\n*)|((?:(?:^|\n)([>*+-]|\d+\.)\s+.*)+)|(?:\!\[([^\]]*?)\]\(([^\)]+?)\))|(\[)|(\](?:\(([^\)]+?)\))?)|(?:(?:^|\n+)([^\s].*)\n(\-{3,}|={3,})(?:\n+|$))|(?:(?:^|\n+)(#{1,3})\s*(.+)(?:\n+|$))|(?:`([^`].*?)`)|(  \n\n*|\n{2,}|__|\*\*|[_*])/gm,
@@ -51,7 +64,6 @@ export default function parse(md) {
 		context = [],
 		out = '',
 		last = 0,
-		links = {},
 		chunk, prev, token, inner, t, p;
 
 	function tag(token) {
@@ -128,7 +140,7 @@ export default function parse(md) {
 		}
 		// Paragraphs
 		else if (token[18] || token[19]) {
-			p = (token[18] || token[19]).trim()
+			p = (token[18] || token[19]).trim();
 			// Right now there is a problem with p regexp,
 			// lists are included in it too, this checks for list once again.
 			// I don't like this solution, but can't come up with other one for


### PR DESCRIPTION
This pull-request tries to solve issue https://github.com/developit/snarkdown/issues/11

I'm not sure that the solution is good, in some places it looks quite hacky. This is just proof of concept I guess? Maybe someone would suggest some better solutions for this problem. This is the reason I didn't add tests right now, but if it will help to review changes, I will update test cases and add some new ones.

I added a lot of comments to the code to describe what I changed, and I also will describe this changes below

- Move `links` to higher scope. This prevent block parsers from loosing links. I'm not sure that this fix is any good, maybe links could be passed as a property to `parse` fn like this?

```
function parse(md, links) {
// ...
  let links = links || {};
```

Example of the issue:

```
# heading with [link]


[link]: http://example.com
```

produces

```
<h1>heading with <a href="undefined">link</a></h1>
```

- Move newline replacement to the end of chain. This fixes excessive linebreaks in some cases

For example this markdown

```
plain text with [link]

[link]: http://example.com
```

Produces this html

```
plain text with <a href="https://example.com">link</a><br />
```

- There are also some changes to tokenizer regex described in code. The part that worries me is that I couldn't come up with a regex, that won't grab lists, so I added additional check for lists in paragraph and this looks hacky

Maybe I'm overthinking this issue, but it literally haunts me now in my dreams, so I really wanted to solve this 😓 

/cc @developit 
