### PR TITLE
Add typings to `files`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "files": [
     "src",
-    "dist"
+    "dist",
+    "snarkdown.d.ts"
   ],
   "homepage": "https://github.com/developit/snarkdown",
   "repository": "developit/snarkdown",


### PR DESCRIPTION
Looks like NPM is dropping the snarkdown.d.ts file when releasing it. Could you please publish a new version with this fix? In the meantime, I'll copy-paste the typings into `node_modules` by hand.

Thanks,
resynth1943